### PR TITLE
Change how TestPyPI publishing is handled

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,10 +1,12 @@
 name: Publish Python distribution to PyPI and TestPyPI
 
 on:
-  push:
-    branches: ["main"]
-    tags: ["*"]
-  workflow_dispatch:
+    pull_request:
+        types: [opened, synchronize, reopened]
+    push:
+        branches: ["main"]
+        tags: ["*"]
+    workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -89,7 +89,7 @@ jobs:
           if not version_match:
               raise ValueError("Could not find version in pyproject.toml")
           current_version = version_match.group(1)
-          new_version = f"{current_version}.dev{sha}"
+          new_version = f"{current_version}+dev.{sha}"
           new_content = re.sub(
               r'version\s*=\s*[\'"][^\'"]*[\'"]',
               f'version = "{new_version}"',

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,74 +8,98 @@ on:
 
 jobs:
   build:
-    name: Build distribution 
+    name: Build distribution
+    if: startsWith(github.ref, 'refs/tags/')  # Only run on tags
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
   publish-to-pypi:
-    name: >-
-      Publish Python  distribution  to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    needs:
-    - build
+    name: Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/unit-averaging 
+      url: https://pypi.org/p/unit-averaging
     permissions:
-      id-token: write  
-
+      id-token: write
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution  to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-to-testpypi:
-    name: Publish Python  distribution  to TestPyPI
-    if: github.ref == 'refs/heads/main'
-    needs:
-    - build
+    name: Publish Python distribution to TestPyPI
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-
     environment:
       name: testpypi
       url: https://test.pypi.org/p/unit-averaging
-
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
+      id-token: write
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish distribution  to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Modify version for TestPyPI
+        run: |
+          python3 << EOF
+          import re
+          import os
+          sha = os.environ['GITHUB_SHA'][:7]
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          version_match = re.search(r'version\s*=\s*[\'"]([^\'"]*)[\'"]', content)
+          if not version_match:
+              raise ValueError("Could not find version in pyproject.toml")
+          current_version = version_match.group(1)
+          new_version = f"{current_version}.dev{sha}"
+          new_content = re.sub(
+              r'version\s*=\s*[\'"][^\'"]*[\'"]',
+              f'version = "{new_version}"',
+              content
+          )
+          with open('pyproject.toml', 'w') as f:
+              f.write(new_content)
+          print(f"Version updated to: {new_version}")
+          EOF
+      - name: Build modified distribution
+        run: python3 -m build
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Changes

This PR changes how TestPyPI build and publish steps work. As before, every push on `main` triggers a publish step for TestPyPI.

Previously, this would fail if the package version did not change relative to the previous commit.

This PR proposes setting package version dynamically as a local version based on the most recent commit in the context to prevent version collisions. 

## Related issues

Closed #51 