### PR TITLE
Change how TestPyPI publishing is handled

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,6 @@ name: Publish Python distribution to PyPI and TestPyPI
 
 on:
   push:
-    branches: ["main"]
     tags: ["*"]
   workflow_dispatch:
 
@@ -34,8 +33,7 @@ jobs:
         path: dist/
 
   publish-to-pypi:
-    name: >-
-      Publish Python  distribution  to PyPI
+    name: Publish Python distribution to PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
@@ -57,7 +55,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python  distribution  to TestPyPI
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' 
     needs:
     - build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

This PR changes how TestPyPI build and publish steps work. Publishing to TestPyPI is now manual-only, to be done to test release candidates. 

## Related issues

Closed #51 